### PR TITLE
Fix broken Gemspec

### DIFF
--- a/logstash-input-cloudwatch.gemspec
+++ b/logstash-input-cloudwatch.gemspec
@@ -1,16 +1,28 @@
 Gem::Specification.new do |s|
-  s.name = 'logstash-input-cloudwatch'
-  s.version         = '2.0.0'
-  s.licenses = ['Apache License (2.0)']
-  s.summary = "Retrieve stats from AWS CloudWatch."
-  s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
-  s.authors = ["Jurgens du Toit"]
-  s.email = 'jrgns@eagerelk.com'
-  s.homepage = "http://eagerelk.com"
+  s.name          = 'logstash-input-cloudwatch'
+  s.version       = '2.0.0'
+  s.licenses      = ['Apache License (2.0)']
+  s.summary       = "Retrieve stats from AWS CloudWatch."
+  s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
+  s.authors       = ["Jurgens du Toit"]
+  s.email         = 'jrgns@eagerelk.com'
+  s.homepage      = "http://eagerelk.com"
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"
+  s.files = Dir[
+    "lib/**/*",
+    "spec/**/*",
+    "*.gemspec",
+    "*.md",
+    "CONTRIBUTORS",
+    "Gemfile",
+    "LICENSE",
+    "NOTICE.TXT",
+    "vendor/jar-dependencies/**/*.jar",
+    "vendor/jar-dependencies/**/*.rb",
+    "VERSION",
+    "docs/**/*",
     'lib/**/*',
     'spec/**/*',
     'vendor/**/*',
@@ -21,7 +33,8 @@ Gem::Specification.new do |s|
     'LICENSE',
     'NOTICE.TXT'
   ]
-   # Tests
+
+  # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Special flag to let us know this is actually a logstash plugin

--- a/logstash-input-cloudwatch.gemspec
+++ b/logstash-input-cloudwatch.gemspec
@@ -11,27 +11,19 @@ Gem::Specification.new do |s|
 
   # Files
   s.files = Dir[
-    "lib/**/*",
-    "spec/**/*",
-    "*.gemspec",
-    "*.md",
-    "CONTRIBUTORS",
-    "Gemfile",
-    "LICENSE",
-    "NOTICE.TXT",
-    "vendor/jar-dependencies/**/*.jar",
-    "vendor/jar-dependencies/**/*.rb",
-    "VERSION",
-    "docs/**/*",
-    'lib/**/*',
-    'spec/**/*',
-    'vendor/**/*',
     '*.gemspec',
     '*.md',
     'CONTRIBUTORS',
+    'docs/**/*',
     'Gemfile',
+    'lib/**/*',
     'LICENSE',
-    'NOTICE.TXT'
+    'NOTICE.TXT',
+    'spec/**/*',
+    'vendor/**/*',
+    'vendor/jar-dependencies/**/*.jar',
+    'vendor/jar-dependencies/**/*.rb',
+    'VERSION',
   ]
 
   # Tests


### PR DESCRIPTION
Gemspec is missing a comma. Granted that there are some duplicate lines as well, might fix that later.

Also `logstash-devutils` isn't a clean install on Ruby 2.3.x+.