### PR TITLE
Logstash 5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Gemfile.lock
 Gemfile.bak
 .bundle
 vendor
+.idea
+.idea/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,8 @@ language: ruby
 cache: bundler
 matrix:
   include:
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=master
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.x
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.0
   - rvm: jruby-1.7.27
-    env: LOGSTASH_BRANCH=5.6
+    env: LOGSTASH_BRANCH=5.5
   fast_finish: true
 install: true
 script: ci/build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.4
+  - Created branch of plug-in which is compatible to logstash 5.5.x (latest logstash-mixin-aws is causing error with AWS SWK V1)
+  - Metric timestamp now points to actual one returned by Cloudwatch API
+  - Made *filters* optional for *AWS/EC2* namespace optional.
+  - Added support for *AWS/ELB* namespace.
+  - Docs: Set the default_codec doc attribute.
+  - Reduce info level logging verbosity #27
+
 ## 2.0.3
   - Update gemspec summary
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,17 @@
+The following is a list of people who have contributed ideas, code, bug
+reports, or in general have helped logstash along its way.
+
+Contributors:
+* Jurgens du Toit (jrgns)
+* Luke Waite (lukewaite)
+* Brandon Weaver (baweaver)
+* João Duarte (jsvd)
+* Jake Landis (jakelandis)
+* Jordan Sissel (jordansissel)
+* Pier-Hugues Pellerin (ph)
+* Rahul Singhai (rahulsinghai)
+
+Note: If you've sent us patches, bug reports, or otherwise contributed to
+Logstash, and you aren't on the list above and want to be, please let us know
+and we'll make sure you're here. Contributions from folks like you are what make
+open source awesome.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,2 +1,0 @@
-# logstash-input-example
-Example input plugin. This should help bootstrap your effort to write your own input plugin!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Logstash CloudWatch Input Plugins
 
+[![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-input-cloudwatch.svg)](https://travis-ci.org/logstash-plugins/logstash-input-cloudwatch)
+
+This is a plugin for [Logstash](https://github.com/elastic/logstash).
+
+It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+
+## Documentation
+
 Pull events from the Amazon Web Services CloudWatch API.
 
 To use this plugin, you *must* have an AWS account, and the following policy:

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
+@files=[]
+
+task :default do
+  system("rake -T")
+end
+
 require "logstash/devutils/rake"

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,6 @@
 :plugin: cloudwatch
 :type: input
++:default_codec: plain
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -112,7 +113,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-access_key_id"]
-===== `access_key_id` 
+===== `access_key_id`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -126,7 +127,7 @@ This plugin uses the AWS SDK and supports several ways to get credentials, which
 5. IAM Instance Profile (available when running inside EC2)
 
 [id="plugins-{type}s-{plugin}-aws_credentials_file"]
-===== `aws_credentials_file` 
+===== `aws_credentials_file`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -144,7 +145,7 @@ file should look like this:
 
 
 [id="plugins-{type}s-{plugin}-combined"]
-===== `combined` 
+===== `combined`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -152,7 +153,7 @@ file should look like this:
 Use this for namespaces that need to combine the dimensions like S3 and SNS.
 
 [id="plugins-{type}s-{plugin}-filters"]
-===== `filters` 
+===== `filters`
 
   * This is a required setting.
   * Value type is <<array,array>>
@@ -264,3 +265,6 @@ The AWS SDK for Ruby defaults to SSL so we preserve that
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
+
++
++:default_codec!:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -94,7 +94,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-access_key_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-aws_credentials_file>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-combined>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-filters>> |<<array,array>>|Yes
+| <<plugins-{type}s-{plugin}-filters>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-metrics>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-namespace>> |<<string,string>>|No
@@ -155,7 +155,7 @@ Use this for namespaces that need to combine the dimensions like S3 and SNS.
 [id="plugins-{type}s-{plugin}-filters"]
 ===== `filters`
 
-  * This is a required setting.
+  * This is an optional setting for AWS/EC2 namespace, but required for others.
   * Value type is <<array,array>>
   * There is no default value for this setting.
 
@@ -165,7 +165,7 @@ This needs to follow the AWS convention of specifiying filters.
 Instances: { 'instance-id' => 'i-12344321' }
 Tags: { "tag:Environment" => "Production" }
 Volumes: { 'attachment.status' => 'attached' }
-Each namespace uniquely support certian dimensions. Please consult the documentation
+Each namespace uniquely support certain dimensions. Please consult the documentation
 to ensure you're using valid filters.
 
 [id="plugins-{type}s-{plugin}-interval"]

--- a/lib/logstash/inputs/cloudwatch.rb
+++ b/lib/logstash/inputs/cloudwatch.rb
@@ -228,7 +228,6 @@ class LogStash::Inputs::CloudWatch < LogStash::Inputs::Base
     event.delete :dimensions
     event[:start_time] = Time.parse(event[:start_time]).utc
     event[:end_time]   = Time.parse(event[:end_time]).utc
-    event[:timestamp]  = event[:end_time]
     LogStash::Util.stringify_symbols(event)
   end
 

--- a/lib/logstash/inputs/cloudwatch.rb
+++ b/lib/logstash/inputs/cloudwatch.rb
@@ -314,6 +314,12 @@ class LogStash::Inputs::CloudWatch < LogStash::Inputs::Base
       @logger.debug "AWS/EBS Volumes: #{volumes}"
 
       { 'VolumeId' => volumes }
+    when 'AWS/ELB'
+      load_balancers = clients[@namespace].describe_load_balancers[:load_balancer_descriptions].flat_map { |e| e[:load_balancer_name] }
+
+      @logger.debug "AWS/ELB ELBs: #{load_balancers}"
+
+      { 'LoadBalancerName' => load_balancers }
     else
       @filters
     end

--- a/logstash-input-cloudwatch.gemspec
+++ b/logstash-input-cloudwatch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-cloudwatch'
-  s.version         = '2.0.3'
+  s.version       = '2.0.4'
   s.licenses      = ['Apache-2.0']
   s.summary       = "Pulls events from the Amazon Web Services CloudWatch API "
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-cloudwatch.gemspec
+++ b/logstash-input-cloudwatch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-cloudwatch'
   s.version         = '2.0.3'
-  s.licenses      = ['Apache License (2.0)']
+  s.licenses      = ['Apache-2.0']
   s.summary       = "Pulls events from the Amazon Web Services CloudWatch API "
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors       = ["Jurgens du Toit"]
@@ -33,9 +33,10 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.1.27"
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'rake', '<= 12.2.1'
   s.add_runtime_dependency 'stud', '>= 0.0.19'
-  s.add_runtime_dependency 'logstash-mixin-aws'
+  s.add_runtime_dependency 'logstash-mixin-aws', '<= 4.2.2'
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/inputs/cloudwatch_spec.rb
+++ b/spec/inputs/cloudwatch_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'logstash/devutils/rspec/spec_helper'
 require 'logstash/inputs/cloudwatch'
 require 'aws-sdk'


### PR DESCRIPTION
- Releasing version 2.0.4
- Created branch of plug-in which is compatible to logstash 5.5.x (latest logstash-mixin-aws is causing error with AWS SWK V1)
- Metric timestamp now points to actual one returned by Cloudwatch API
- Made *filters* optional for *AWS/EC2* namespace optional.
- Added support for *AWS/ELB* namespace.
- Docs: Set the default_codec doc attribute.
- Reduce info level logging verbosity #27
