### PR TITLE
Move CloudWatch to v2 of AWS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+  - Changed to use the underlying version of the AWS SDK to v2. [#32](https://github.com/logstash-plugins/logstash-input-cloudwatch/pull/32)
+  - Fixed License definition in gemspec to be valid SPDX identifier [#32](https://github.com/logstash-plugins/logstash-input-cloudwatch/pull/32)
+  - Fixed fatal error when using secret key attribute in config [#30](https://github.com/logstash-plugins/logstash-input-cloudwatch/issues/30)
+
 ## 2.1.1
   - Docs: Set the default_codec doc attribute.
 

--- a/logstash-input-cloudwatch.gemspec
+++ b/logstash-input-cloudwatch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-cloudwatch'
-  s.version         = '2.1.1'
-  s.licenses      = ['Apache License (2.0)']
+  s.version         = '2.2.0'
+  s.licenses      = ['Apache-2.0']
   s.summary       = "Pulls events from the Amazon Web Services CloudWatch API "
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors       = ["Jurgens du Toit"]

--- a/spec/inputs/cloudwatch_spec.rb
+++ b/spec/inputs/cloudwatch_spec.rb
@@ -4,7 +4,7 @@ require 'aws-sdk'
 
 describe LogStash::Inputs::CloudWatch do
   before do
-    AWS.stub!
+    Aws.config[:stub_responses] = true
     Thread.abort_on_exception = true
   end
 

--- a/spec/inputs/cloudwatch_spec.rb
+++ b/spec/inputs/cloudwatch_spec.rb
@@ -12,7 +12,7 @@ describe LogStash::Inputs::CloudWatch do
     let(:config) {
       {
         'access_key_id' => '1234',
-        'secret_access_key' => 'secret',
+        'secret_access_key' => LogStash::Util::Password.new('secret'),
         'namespace' => 'AWS/EC2',
         'filters' => { 'instance-id' => 'i-12344321' },
         'region' => 'us-east-1'
@@ -24,6 +24,7 @@ describe LogStash::Inputs::CloudWatch do
       expect { subject.register }.to_not raise_error
     end
   end
+
 
   context "EC2 events" do
     let(:config) {

--- a/spec/integration/cloudwatch_spec.rb
+++ b/spec/integration/cloudwatch_spec.rb
@@ -1,0 +1,26 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/cloudwatch"
+require "aws-sdk"
+
+describe LogStash::Inputs::CloudWatch, :integration => true do
+
+  let(:settings)  {  { "access_key_id" => ENV['AWS_ACCESS_KEY_ID'],
+                       "secret_access_key" => LogStash::Util::Password.new(ENV['AWS_SECRET_ACCESS_KEY']),
+                       "region" => ENV["AWS_REGION"] || "us-east-1",
+                       "namespace" => "AWS/S3",
+                       'filters' => { "BucketName" => "*"},
+                       'metrics' => ["BucketSizeBytes","NumberOfObjects"]
+
+  }}
+
+  def metrics_for(settings)
+    cw = LogStash::Inputs::CloudWatch.new(settings)
+    cw.register
+    cw.send('metrics_for', settings['namespace'])
+  end
+
+  #
+  it "should not raise a type error when using a password" do
+    expect{metrics_for(settings)}.not_to raise_error
+  end
+end


### PR DESCRIPTION
Use v2 of CloudWatch API -

  enables use of more standard options from the AWS mixin
  fixes #30 (includes rudimentary IT to test correct behavior with
   password types)

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
