### PR TITLE
Allow support for optional filters for `AWS/EC2` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.2
+  - Added ability to use AWS/EC2 namespace without requiring filters
+
 ## 2.2.1
   - Fixed README.md link to request metric support to point to this repo [#34](https://github.com/logstash-plugins/logstash-input-cloudwatch/pull/34)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -95,7 +95,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-aws_credentials_file>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-combined>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-endpoint>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-filters>> |<<array,array>>|Yes
+| <<plugins-{type}s-{plugin}-filters>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-metrics>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-namespace>> |<<string,string>>|No
@@ -168,9 +168,12 @@ guaranteed to work correctly with the AWS SDK.
 [id="plugins-{type}s-{plugin}-filters"]
 ===== `filters` 
 
-  * This is a required setting.
+  * This is an optional setting.
   * Value type is <<array,array>>
   * There is no default value for this setting.
+
+[Note]
+ This setting is only optional when the namespace is `AWS/EC2` - otherwise this is still a required field.
 
 Specify the filters to apply when fetching resources:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -53,7 +53,7 @@ A sample policy for EC2 metrics is as follows:
 
 See http://aws.amazon.com/iam/ for more details on setting up AWS identities.
 
-# Configuration Example
+===== Configuration Example
 [source, ruby]
     input {
       cloudwatch {
@@ -64,6 +64,7 @@ See http://aws.amazon.com/iam/ for more details on setting up AWS identities.
       }
     }
 
+[source, ruby]
     input {
       cloudwatch {
         namespace => "AWS/EBS"
@@ -73,6 +74,7 @@ See http://aws.amazon.com/iam/ for more details on setting up AWS identities.
       }
     }
 
+[source, ruby]
     input {
       cloudwatch {
         namespace => "AWS/RDS"
@@ -95,7 +97,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-aws_credentials_file>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-combined>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-endpoint>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-filters>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-filters>> |<<array,array>>|See <<plugins-{type}s-{plugin}-filters,note>>
 | <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-metrics>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-namespace>> |<<string,string>>|No
@@ -168,12 +170,11 @@ guaranteed to work correctly with the AWS SDK.
 [id="plugins-{type}s-{plugin}-filters"]
 ===== `filters` 
 
-  * This is an optional setting.
+  * This setting can be required or optional. See note below.
   * Value type is <<array,array>>
   * There is no default value for this setting.
 
-[Note]
- This setting is only optional when the namespace is `AWS/EC2` - otherwise this is still a required field.
+NOTE: This setting is optional when the namespace is `AWS/EC2` - otherwise this is a required field.
 
 Specify the filters to apply when fetching resources:
 

--- a/lib/logstash/inputs/cloudwatch.rb
+++ b/lib/logstash/inputs/cloudwatch.rb
@@ -185,8 +185,7 @@ class LogStash::Inputs::CloudWatch < LogStash::Inputs::Base
         @logger.debug "DPs: #{datapoints.data}"
         # For every event in the resource
         datapoints[:datapoints].each do |datapoint|
-          event_hash = datapoint.to_hash
-          event_hash.merge! options
+          event_hash = datapoint.to_hash.update(options)
           event_hash[dimension.to_sym] = resource
           event = LogStash::Event.new(cleanup(event_hash))
           decorate(event)
@@ -209,8 +208,7 @@ class LogStash::Inputs::CloudWatch < LogStash::Inputs::Base
     @logger.debug "DPs: #{datapoints.data}"
 
     datapoints[:datapoints].each do |datapoint|
-      event_hash = datapoint.to_hash
-      event_hash.merge! options
+      event_hash = datapoint.to_hash.update(options)
       aws_filters.each do |dimension|
         event_hash[dimension[:name].to_sym] = dimension[:value]
       end

--- a/logstash-input-cloudwatch.gemspec
+++ b/logstash-input-cloudwatch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-cloudwatch'
-  s.version         = '2.2.1'
+  s.version         = '2.2.2'
   s.licenses      = ['Apache-2.0']
   s.summary       = "Pulls events from the Amazon Web Services CloudWatch API "
   s.description   = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/cloudwatch_spec.rb
+++ b/spec/inputs/cloudwatch_spec.rb
@@ -3,65 +3,70 @@ require 'logstash/inputs/cloudwatch'
 require 'aws-sdk'
 
 describe LogStash::Inputs::CloudWatch do
+  subject { LogStash::Inputs::CloudWatch.new(config) }
+  let(:config) {
+    {
+        'access_key_id' => '1234',
+        'secret_access_key' => 'secret',
+        'metrics' => [ 'CPUUtilization' ],
+        'region' => 'us-east-1'
+    }
+  }
+
+
   before do
     Aws.config[:stub_responses] = true
     Thread.abort_on_exception = true
   end
 
-  describe '#register' do
-    let(:config) {
-      {
-        'access_key_id' => '1234',
-        'secret_access_key' => LogStash::Util::Password.new('secret'),
-        'namespace' => 'AWS/EC2',
-        'filters' => { 'instance-id' => 'i-12344321' },
-        'region' => 'us-east-1'
-      }
-    }
-    subject { LogStash::Inputs::CloudWatch.new(config) }
+  shared_examples_for 'it requires filters' do
+    context 'without filters' do
+      it "raises an error" do
+        expect { subject.register }.to raise_error
+      end
+    end
 
-    it "registers succesfully" do
-      expect { subject.register }.to_not raise_error
+    context 'with filters' do
+      let (:config) { super().merge('filters' => { 'tag:Monitoring' => 'Yes' })}
+
+      it "registers succesfully" do
+        expect { subject.register }.to_not raise_error
+      end
     end
   end
 
+  shared_examples_for 'it does not require filters' do
+    context 'without filters' do
+      it "registers succesfully" do
+        expect { subject.register }.to_not raise_error
+      end
+    end
 
-  context "EC2 events" do
-    let(:config) {
-      {
-        'access_key_id' => '1234',
-        'secret_access_key' => 'secret',
-        'namespace' => 'AWS/EC2',
-        'metrics' => [ 'CPUUtilization' ],
-        'filters' => { 'tag:Monitoring' => 'Yes' },
-        'region' => 'us-east-1'
-      }
-    }
+    context 'with filters' do
+      let (:config) { super().merge('filters' => { 'tag:Monitoring' => 'Yes' })}
+
+      it "registers succesfully" do
+        expect { subject.register }.to_not raise_error
+      end
+    end
   end
 
-  context "EBS events" do
-    let(:config) {
-      {
-        'access_key_id' => '1234',
-        'secret_access_key' => 'secret',
-        'namespace' => 'AWS/EBS',
-        'metrics' => [ 'VolumeQueueLength' ],
-        'filters' => { 'tag:Monitoring' => 'Yes' },
-        'region' => 'us-east-1'
-      }
-    }
-  end
+  describe '#register' do
 
-  context "RDS events" do
-    let(:config) {
-      {
-        'access_key_id' => '1234',
-        'secret_access_key' => 'secret',
-        'namespace' => 'AWS/RDS',
-        'metrics' => [ 'CPUUtilization', 'CPUCreditUsage' ],
-        'filters' => { 'EngineName' => 'mysql' },
-        'region' => 'us-east-1'
-      }
-    }
+    context "EC2 namespace" do
+      let(:config) { super().merge('namespace' => 'AWS/EC2') }
+      it_behaves_like 'it does not require filters'
+    end
+
+    context "EBS namespace" do
+      let(:config) { super().merge('namespace' => 'AWS/EBS') }
+      it_behaves_like 'it requires filters'
+    end
+
+    context "RDS namespace" do
+      let(:config) { super().merge('namespace' => 'AWS/RDS') }
+      it_behaves_like 'it requires filters'
+    end
+
   end
 end

--- a/spec/inputs/cloudwatch_spec.rb
+++ b/spec/inputs/cloudwatch_spec.rb
@@ -22,7 +22,7 @@ describe LogStash::Inputs::CloudWatch do
   shared_examples_for 'it requires filters' do
     context 'without filters' do
       it "raises an error" do
-        expect { subject.register }.to raise_error
+        expect { subject.register }.to raise_error(StandardError)
       end
     end
 


### PR DESCRIPTION
This commit brings in #13 and also includes fixes to ensure that this plugin is compatible with v2 of the AWS Ruby SDK