### PR TITLE
Metric timestamp was being lost due to over-writing by end_time

### DIFF
--- a/lib/logstash/inputs/cloudwatch.rb
+++ b/lib/logstash/inputs/cloudwatch.rb
@@ -216,7 +216,6 @@ class LogStash::Inputs::CloudWatch < LogStash::Inputs::Base
     event.delete :dimensions
     event[:start_time] = Time.parse(event[:start_time]).utc
     event[:end_time]   = Time.parse(event[:end_time]).utc
-    event[:timestamp]  = event[:end_time]
     LogStash::Util.stringify_symbols(event)
   end
 


### PR DESCRIPTION
fixes issue logstash-plugins/logstash-input-cloudwatch#23